### PR TITLE
add docker ignore

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,1 @@
+/node_modules

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,1 @@
+/node_modules


### PR DESCRIPTION
**PR Description**

This PR adds .dockerignore to the frontend and backend folders. When the docker builds the containers, it will try to mount the local node_modules folder to the container. This will cause an issue because the local node_modules works for the local OS but not within the container. To completely isolate the environment, we use .dockerignore to tell the docker container to use its internal node_modules.